### PR TITLE
docs: add repository relocation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,46 +1,16 @@
-# Nextkit - A nextjs starter kit (DEVELOPEMENT)
+# This repository has moved!
 
-Accelerate NextJS development with Nextkit: a pre-configured Next.js,
-TypeScript, and Tailwind boilerplate.
+🚀 **This project has been migrated to a new location:**  
+[https://github.com/thekrishdas/folio](https://github.com/thekrishdas/folio)
 
-## Cloning:
+Please update your bookmarks and links to point to the new repository.  
+All future development will occur there.
 
-### Clone in Nextkit:
+---
 
-```sh
-git clone -b next@15 https://github.com/Krish-Das/nextkit.git
-```
+### Why was it moved?
+- Consolidated under the main organization account (not really)
+- Better maintainability and collaboration structure
 
-### or clone in current directory:
-
-```sh
-git clone -b next@15 https://github.com/Krish-Das/nextkit.git .
-```
-
-### or clone single branch in current directory:
-
-```sh
-git clone -b next@15 --single-branch https://github.com/Krish-Das/nextkit.git .
-```
-
-## Running locally
-
-```sh
-npm run dev
-```
-
-### Notes:
-
-This branch does not use any UI-library of any kind and serves as a clean
-starting point.
-
-1. Package versions
-
-- Next 15
-- React 19
-- Tailwind 4
-
-2. Formatting
-
-- @ianvs/prettier-plugin-sort-imports
-- prettier-plugin-tailwindcss
+### Need help?
+Open an issue in the [new repository](https://github.com/thekrishdas/folio/issues) if you have questions.


### PR DESCRIPTION
Update `README.md` indicating this repository has moved to: https://github.com/thekrishdas/folio

The notice includes:
- Prominent new location link
- Brief migration reason
- Instructions for contributors